### PR TITLE
Enable npu compile in compiler.py

### DIFF
--- a/intel_npu_acceleration_library/compiler.py
+++ b/intel_npu_acceleration_library/compiler.py
@@ -61,7 +61,7 @@ def compile(model: torch.nn.Module, config: CompilerConfig) -> torch.nn.Module:
     with torch.no_grad():
         # Model lowering to NPU ops
         if config.use_to:
-            model = model
+            model = model.to("npu")
         else:
             # General optimizations
             apply_general_optimizations(model)


### PR DESCRIPTION
Hi,
I tried to run "profile_mlp.py", but i found that NPU usage was none, so i debugged the code and found that may be you missed the `.to("npu")` in compiler.py. After the modifcation "profile_mlp.py" can run with NPU.